### PR TITLE
Expose bindings for the Playdate System Menu API

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -1,13 +1,17 @@
 use {
     crate::pd_func_caller,
-    alloc::format,
+    alloc::{format, string::String, vec::Vec},
     anyhow::Error,
-    core::ptr,
+    core::{ptr, convert::TryInto},
     crankstart_sys::{ctypes::c_void, size_t},
+    cstr_core::CStr,
     cstr_core::CString,
 };
 
+use core::mem;
+
 pub use crankstart_sys::PDButtons;
+pub use crankstart_sys::PDMenuItem;
 
 static mut SYSTEM: System = System(ptr::null_mut());
 
@@ -34,6 +38,70 @@ impl System {
 
     pub fn set_update_callback(&self, f: crankstart_sys::PDCallbackFunction) -> Result<(), Error> {
         pd_func_caller!((*self.0).setUpdateCallback, f, ptr::null_mut())
+    }
+
+    pub fn add_menu_item(&self, title: &str, f: crankstart_sys::PDMenuItemCallbackFunction) -> Result<MenuItem, Error> {
+        let c_title = CString::new(title).map_err(Error::msg)?;
+        let item = pd_func_caller!(
+            (*self.0).addMenuItem, 
+            c_title.as_ptr(), 
+            f, 
+            ptr::null_mut()
+        )?;
+        Ok(MenuItem(item))
+    }
+
+    pub fn add_checkmark_menu_item(&self, title: &str, initially_checked: bool, f: crankstart_sys::PDMenuItemCallbackFunction) -> Result<MenuItem, Error> {
+        let c_title = CString::new(title).map_err(Error::msg)?;
+        let item = pd_func_caller!(
+            (*self.0).addCheckmarkMenuItem, 
+            c_title.as_ptr(), 
+            if initially_checked { 1 } else { 0 },
+            f, 
+            ptr::null_mut()
+        )?;
+        Ok(MenuItem(item))
+    }
+
+    pub fn add_options_menu_item(&self, title: &str, options: Vec<&str>, f: crankstart_sys::PDMenuItemCallbackFunction) -> Result<MenuItem, Error> {
+        let c_title = CString::new(title).map_err(Error::msg)?;
+
+        let mut c_options = Vec::with_capacity(options.len());
+        for option in options {
+            let c_option = CString::new(option).map_err(Error::msg)?;
+            let c_option_ptr = c_option.as_ptr();
+            // Here, we need to forget our values or they won't live long enough
+            // for Playdate OS to use them
+            mem::forget(c_option);
+            c_options.push(
+                c_option_ptr
+            )
+        }
+
+        let opt_ptr = c_options.as_mut_ptr();
+        let opt_len = c_options.len();
+        let opt_len_i32: i32 = opt_len.try_into().map_err(Error::msg)?;
+
+        let item = pd_func_caller!(
+            (*self.0).addOptionsMenuItem, 
+            c_title.as_ptr(),
+            opt_ptr,
+            opt_len_i32,
+            f,
+            ptr::null_mut()
+        )?;
+
+        // After the call, we manually drop our forgotten values so as to not
+        // leak memory.
+        for c_option in c_options {
+            mem::drop(c_option);
+        }
+
+        Ok(MenuItem(item))
+    }
+
+    pub fn remove_all_menu_items (&self) -> Result<(), Error> {
+        pd_func_caller!((*self.0).removeAllMenuItems)
     }
 
     pub fn get_button_state(&self) -> Result<(PDButtons, PDButtons, PDButtons), Error> {
@@ -93,5 +161,49 @@ impl System {
 
     pub fn draw_fps(&self, x: i32, y: i32) -> Result<(), Error> {
         pd_func_caller!((*self.0).drawFPS, x, y)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct MenuItem(*mut crankstart_sys::PDMenuItem);
+
+impl MenuItem {
+    pub fn remove (&self) -> Result<(), Error> {
+        let system = System::get();
+        pd_func_caller!((*system.0).removeMenuItem, self.0)
+    }
+
+    pub fn get_title (&self) -> Result<String, Error> {
+        let system = System::get();
+        let c_title = pd_func_caller!((*system.0).getMenuItemTitle, self.0)?;
+        let title = unsafe {
+            CStr::from_ptr(c_title).to_string_lossy().into_owned()
+        };
+        Ok(title)
+    }
+
+    pub fn set_title (&self, new_title: &str) -> Result<(), Error> {
+        let system = System::get();
+        let c_title = CString::new(new_title).map_err(Error::msg)?;
+        pd_func_caller!((*system.0).setMenuItemTitle, self.0, c_title.as_ptr())
+    }
+
+    pub fn get_value (&self) -> Result<i32, Error> {
+        let system = System::get();
+        pd_func_caller!((*system.0).getMenuItemValue, self.0)
+    }
+
+    pub fn set_value (&self, new_value: i32) -> Result<(), Error> {
+        let system = System::get();
+        pd_func_caller!((*system.0).setMenuItemValue, self.0, new_value)
+    }
+
+    // For checkmark menu items
+    pub fn get_checked (&self) -> Result<bool, Error> {
+        Ok(self.get_value()? == 1)
+    }
+
+    pub fn set_checked (&self, new_value: bool) -> Result<(), Error> {
+        self.set_value(if new_value { 1 } else { 0 })
     }
 }


### PR DESCRIPTION
👋  This PR adds bindings for interacting with the System Menu.

For example:

```rust
unsafe extern "C" fn callback (_: *mut c_void) {
    log_to_console!("Hello, system menu!")
}
        
system.add_menu_item("say hi", Some(callback))?;
```

<img src=https://user-images.githubusercontent.com/26578100/164999368-30369109-8982-408c-bf60-b5b762c43e55.png width=400/>

It also supports "checkmark" and "options" menu items:

```rust
let checkbox = system.add_checkmark_menu_item("cool?", true, Some(callback))?;

let is_cool = checkbox.get_checked()?; // true/false


let options = system.add_options_menu_item("choice", vec![
    "one", "two", "three"
], Some(callback))?; 

let selected_index = options.get_value(); // 0, 1, or 2
```

<img src=https://user-images.githubusercontent.com/26578100/164999503-2c7ad7d1-1d0d-4074-bc4d-d8ba825b890c.png width=400 />

Totally open to feedback/thoughts on this one since it's a bit bigger than my previous PRs and involves a bit of API design 🙂 