### PR TITLE
Add bindings for playdate->system->error

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -78,6 +78,26 @@ impl System {
         }
     }
 
+    pub fn error(text: &str) {
+        unsafe {
+            if SYSTEM.0 != ptr::null_mut() {
+                if let Ok(c_text) = CString::new(text) {
+                    let error_fn = (*SYSTEM.0).error.expect("error");
+                    error_fn(c_text.as_ptr() as *mut crankstart_sys::ctypes::c_char);
+                }
+            }
+        }
+    }
+
+    pub fn error_raw(text: &str) {
+        unsafe {
+            if SYSTEM.0 != ptr::null_mut() {
+                let error_fn = (*SYSTEM.0).error.expect("error");
+                error_fn(text.as_ptr() as *mut crankstart_sys::ctypes::c_char);
+            }
+        }
+    }
+
     pub fn get_seconds_since_epoch(&self) -> Result<(usize, usize), Error> {
         let mut miliseconds = 0;
         let seconds = pd_func_caller!((*self.0).getSecondsSinceEpoch, &mut miliseconds)?;


### PR DESCRIPTION
Adds bindings for [`void playdate->system->error(const char* format, ...)
 `](https://sdk.play.date/1.13.1/Inside%20Playdate%20with%20C.html#f-system.error)

> Calls the log function, outputting an error in red to the console, then pauses execution.

`log_to_console_raw` already existed so I also implemented `error_raw`.