### PR TITLE
RFC: start of audio system

### DIFF
--- a/src/sound.rs
+++ b/src/sound.rs
@@ -1,0 +1,107 @@
+//! `Sound` is the parent structure for the Playdate audio API, and you can get access specific
+//! subsystems through its get methods.  For example, to play an audio sample (sound effect):
+//!
+//! ```rust
+//! let sound = Sound::get();
+//! let player = sound.get_sample_player()?;
+//! let mut sample = sound.load_audio_sample("test.wav")?;
+//! player.set_sample(&mut sample)?;
+//! player.play(1, 1.0)?;
+//! ```
+
+use crate::{log_to_console, pd_func_caller, pd_func_caller_log};
+use crankstart_sys::ctypes;
+
+use anyhow::{anyhow, ensure, Error, Result};
+use core::ptr;
+use cstr_core::CString;
+
+pub mod sampleplayer;
+pub use sampleplayer::{AudioSample, SamplePlayer};
+
+// When the Playdate system struct is created, it passes the given playdate_sound to Sound::new,
+// which then replaces this.
+static mut SOUND: Sound = Sound::null();
+
+/// `Sound` is the main interface to the Playdate audio subsystems.
+#[derive(Clone, Debug)]
+pub struct Sound {
+    raw_sound: *const crankstart_sys::playdate_sound,
+
+    // Each audio API subsystem has a struct with all of the relevant functions for that subsystem.
+    // These functions are used repeatedly, so pointers to them are stored here for convenience.
+    raw_sample: *const crankstart_sys::playdate_sound_sample,
+    raw_sample_player: *const crankstart_sys::playdate_sound_sampleplayer,
+}
+
+// Not implemented: addSource, removeSource, setMicCallback, and getHeadphoneState (waiting on
+// crankstart callback strategy), getDefaultChannel, addChannel, removeChannel.
+impl Sound {
+    const fn null() -> Self {
+        Self {
+            raw_sound: ptr::null(),
+            raw_sample: ptr::null(),
+            raw_sample_player: ptr::null(),
+        }
+    }
+
+    /// Internal: builds the `Sound` struct from the pointers given in the Playdate SDK after it's started.
+    #[allow(clippy::new_ret_no_self)]
+    pub(crate) fn new(raw_sound: *const crankstart_sys::playdate_sound) -> Result<()> {
+        ensure!(!raw_sound.is_null(), "Null pointer passed to Sound::new");
+
+        // Get supported subsystem pointers.
+        let raw_sample = unsafe { (*raw_sound).sample };
+        ensure!(!raw_sample.is_null(), "Null sound.sample");
+        let raw_sample_player = unsafe { (*raw_sound).sampleplayer };
+        ensure!(!raw_sample_player.is_null(), "Null sound.sampleplayer");
+
+        let sound = Self {
+            raw_sound,
+            raw_sample,
+            raw_sample_player,
+        };
+        unsafe { SOUND = sound };
+        Ok(())
+    }
+
+    /// Gets a handle to the Sound system.  This is the primary entry point for users.
+    pub fn get() -> Self {
+        unsafe { SOUND.clone() }
+    }
+
+    /// Get a `SamplePlayer` that can be used to play sound effects.
+    pub fn get_sample_player(&self) -> Result<SamplePlayer> {
+        let raw_player = pd_func_caller!((*self.raw_sample_player).newPlayer)?;
+        ensure!(!raw_player.is_null(), "Null returned from newPlayer");
+        SamplePlayer::new(self.raw_sample_player, raw_player)
+    }
+
+    /// Loads an `AudioSample` sound effect.  Assign it to a `SamplePlayer` with
+    /// `SamplePlayer.set_sample`.
+    pub fn load_audio_sample(&self, sample_path: &str) -> Result<AudioSample> {
+        let sample_path_c = CString::new(sample_path).map_err(Error::msg)?;
+        let arg_ptr = sample_path_c.as_ptr() as *const ctypes::c_char;
+        let raw_audio_sample = pd_func_caller!((*self.raw_sample).load, arg_ptr)?;
+        ensure!(
+            !raw_audio_sample.is_null(),
+            "Null returned from sample.load"
+        );
+        AudioSample::new(self.raw_sample, raw_audio_sample)
+    }
+
+    /// Returns the sound engine's current time, in frames, 44.1k per second.
+    pub fn get_current_time(&self) -> Result<ctypes::c_uint> {
+        pd_func_caller!((*self.raw_sound).getCurrentTime)
+    }
+
+    /// Sets which audio outputs should be active.  Note: if you disable headphones and enable
+    /// speaker, sound will be played through the speaker even if headphones are plugged in.
+    pub fn set_outputs_active(&self, headphone: bool, speaker: bool) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_sound).setOutputsActive,
+            headphone as ctypes::c_int,
+            speaker as ctypes::c_int
+        )
+    }
+}

--- a/src/sound/fileplayer.rs
+++ b/src/sound/fileplayer.rs
@@ -1,0 +1,180 @@
+use crate::{pd_func_caller, pd_func_caller_log};
+use crankstart_sys::ctypes;
+
+use anyhow::{anyhow, ensure, Error, Result};
+use cstr_core::CString;
+
+/// Note: Make sure you hold on to a FilePlayer until the file has played as much as you want,
+/// because dropping it will stop playback.
+#[derive(Debug)]
+pub struct FilePlayer {
+    raw_subsystem: *const crankstart_sys::playdate_sound_fileplayer,
+    raw_player: *mut crankstart_sys::FilePlayer,
+}
+
+impl Drop for FilePlayer {
+    fn drop(&mut self) {
+        // Use _log to leak rather than fail
+        pd_func_caller_log!((*self.raw_subsystem).freePlayer, self.raw_player);
+    }
+}
+
+// Not implemented: newPlayer (use Sound::get_file_player), setFinishCallback and fadeVolume
+// (waiting on crankstart callback strategy), and setLoopRange (does not seem to do anything).
+impl FilePlayer {
+    pub(crate) fn new(
+        raw_subsystem: *const crankstart_sys::playdate_sound_fileplayer,
+        raw_player: *mut crankstart_sys::FilePlayer,
+    ) -> Result<Self> {
+        ensure!(
+            !raw_subsystem.is_null(),
+            "Null pointer given as subsystem to FilePlayer::new"
+        );
+        ensure!(
+            !raw_player.is_null(),
+            "Null pointer given as player to FilePlayer::new"
+        );
+        Ok(Self {
+            raw_subsystem,
+            raw_player,
+        })
+    }
+
+    /// Loads the given file into the player.  Unlike with SamplePlayer, you must give the
+    /// compiled audio filename here, e.g. "file.pda" instead of "file.wav".  MP3 files are
+    /// not compiled, so they keep their original .mp3 extension.
+    pub fn load_into_player(&self, file_path: &str) -> Result<()> {
+        let file_path_c = CString::new(file_path).map_err(Error::msg)?;
+        let arg_ptr = file_path_c.as_ptr() as *const ctypes::c_char;
+        let result = pd_func_caller!(
+            (*self.raw_subsystem).loadIntoPlayer,
+            self.raw_player,
+            arg_ptr
+        )?;
+        if result == 1 {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "load_into_player given nonexistent file '{}'",
+                file_path
+            ))
+        }
+    }
+
+    /// Play the file 'repeat_count' times; if 0, play until `stop` is called.  See set_loop_range
+    /// for the portion of the file that will repeat.
+    pub fn play(&self, repeat_count: ctypes::c_int) -> Result<()> {
+        let result = pd_func_caller!((*self.raw_subsystem).play, self.raw_player, repeat_count,)?;
+        if result == 1 {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "fileplayer.play should return 1; returned {}",
+                result
+            ))
+        }
+    }
+
+    /// Can be used to stop a played file early, or stop one that's repeating endlessly because
+    /// 'repeat' was set to 0.
+    pub fn stop(&self) -> Result<()> {
+        pd_func_caller!((*self.raw_subsystem).stop, self.raw_player)
+    }
+
+    /// Pause playback.  To resume playback at the same point, use play().
+    pub fn pause(&self) -> Result<()> {
+        pd_func_caller!((*self.raw_subsystem).pause, self.raw_player)
+    }
+
+    /// Returns whether the player is currently playing the file.
+    pub fn is_playing(&self) -> Result<bool> {
+        let result = pd_func_caller!((*self.raw_subsystem).isPlaying, self.raw_player)?;
+        Ok(result == 1)
+    }
+
+    /// How much audio to buffer, in seconds.  Larger buffers use more memory but help avoid
+    /// underruns, which can cause stuttering (see set_stop_on_underrun).
+    pub fn set_buffer_length(&self, length: f32) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setBufferLength,
+            self.raw_player,
+            length
+        )
+    }
+
+    /// If set to true, and the buffer runs out of data (known as an underrun), the player
+    /// will stop playing.  If false (the default), the player will continue playback as soon
+    /// as more data is available; this will come across as audio stuttering, particularly
+    /// with small buffer sizes.  (Note that Inside Playdate with C says the reverse, but
+    /// seems wrong.)
+    pub fn set_stop_on_underrun(&self, stop: bool) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setStopOnUnderrun,
+            self.raw_player,
+            stop as ctypes::c_int
+        )
+    }
+
+    /// Returns whether the buffer has underrun.
+    pub fn did_underrun(&self) -> Result<bool> {
+        let result = pd_func_caller!((*self.raw_subsystem).didUnderrun, self.raw_player)?;
+        Ok(result == 1)
+    }
+
+    /// Returns the current offset into the file, in seconds, increasing as it plays.
+    pub fn get_offset(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getOffset, self.raw_player)
+    }
+
+    /// Set how far into the file to start playing, in seconds.
+    pub fn set_offset(&self, offset: f32) -> Result<()> {
+        pd_func_caller!((*self.raw_subsystem).setOffset, self.raw_player, offset)
+    }
+
+    /// Gets the current volume of the left and right audio channels, out of 1.
+    pub fn get_volume(&self) -> Result<(f32, f32)> {
+        let mut left = 0.0;
+        let mut right = 0.0;
+        pd_func_caller!(
+            (*self.raw_subsystem).getVolume,
+            self.raw_player,
+            &mut left,
+            &mut right,
+        )?;
+        Ok((left, right))
+    }
+
+    /// Sets the volume of the left and right audio channels, out of 1.
+    pub fn set_volume(&self, left: f32, right: f32) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setVolume,
+            self.raw_player,
+            left,
+            right
+        )
+    }
+
+    /// Gets the current playback speed.
+    pub fn get_rate(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getRate, self.raw_player)
+    }
+
+    /// Sets the playback speed of the player; 1.0 is normal speed, 0.5 is down an octave,
+    /// 2.0 is up one, etc.
+    pub fn set_rate(&self, playback_speed: f32) -> Result<()> {
+        ensure!(
+            playback_speed >= 0.0,
+            "FilePlayer cannot play in reverse (playback_speed < 0)"
+        );
+        pd_func_caller!(
+            (*self.raw_subsystem).setRate,
+            self.raw_player,
+            playback_speed
+        )
+    }
+
+    /// Returns the length of the loaded file, in seconds.
+    pub fn get_length(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getLength, self.raw_player)
+    }
+}

--- a/src/sound/sampleplayer.rs
+++ b/src/sound/sampleplayer.rs
@@ -1,0 +1,198 @@
+use crate::{log_to_console, pd_func_caller, pd_func_caller_log};
+use crankstart_sys::ctypes;
+
+use anyhow::{anyhow, ensure, Error, Result};
+
+/// Note: Make sure you hold on to a SamplePlayer until the sample has played as much as you want,
+/// because dropping it will stop playback.
+#[derive(Debug)]
+pub struct SamplePlayer {
+    raw_subsystem: *const crankstart_sys::playdate_sound_sampleplayer,
+    raw_player: *mut crankstart_sys::SamplePlayer,
+}
+
+impl Drop for SamplePlayer {
+    fn drop(&mut self) {
+        // Use _log to leak rather than fail
+        pd_func_caller_log!((*self.raw_subsystem).freePlayer, self.raw_player);
+    }
+}
+
+// Not implemented: newPlayer (use Sound::get_sample_player), and setFinishCallback and setLoopCallback
+// (waiting on crankstart callback strategy).
+impl SamplePlayer {
+    pub(crate) fn new(
+        raw_subsystem: *const crankstart_sys::playdate_sound_sampleplayer,
+        raw_player: *mut crankstart_sys::SamplePlayer,
+    ) -> Result<Self> {
+        ensure!(
+            !raw_subsystem.is_null(),
+            "Null pointer given as subsystem to SamplePlayer::new"
+        );
+        ensure!(
+            !raw_player.is_null(),
+            "Null pointer given as player to SamplePlayer::new"
+        );
+        Ok(Self {
+            raw_subsystem,
+            raw_player,
+        })
+    }
+
+    /// Sets the sound effect to be played by this player.
+    pub fn set_sample(&self, audio_sample: &mut AudioSample) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setSample,
+            self.raw_player,
+            audio_sample.raw_audio_sample
+        )
+    }
+
+    /// Play the sample 'repeat_count' times; if 0, play until `stop` is called; if -1, play
+    /// forward, backward, forward, etc.  (See set_play_range to change which part is looped.)
+    /// 'playback_speed' is how fast the sample plays; 1.0 is normal speed, 0.5 is down an octave,
+    /// 2.0 is up one, etc.  A negative rate plays the sample in reverse.
+    pub fn play(&self, repeat_count: ctypes::c_int, playback_speed: f32) -> Result<()> {
+        let result = pd_func_caller!(
+            (*self.raw_subsystem).play,
+            self.raw_player,
+            repeat_count,
+            playback_speed
+        )?;
+        if result == 1 {
+            Ok(())
+        } else {
+            Err(anyhow!(
+                "sampleplayer.play should return 1; returned {}",
+                result
+            ))
+        }
+    }
+
+    /// Can be used to stop a sample early, or stop one that's repeating endlessly because 'repeat'
+    /// was set to 0.
+    pub fn stop(&self) -> Result<()> {
+        pd_func_caller!((*self.raw_subsystem).stop, self.raw_player)
+    }
+
+    /// Pause or resume playback.
+    pub fn set_paused(&self, paused: bool) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setPaused,
+            self.raw_player,
+            paused as ctypes::c_int
+        )
+    }
+
+    /// Returns whether the player is currently playing the sample.
+    pub fn is_playing(&self) -> Result<bool> {
+        let result = pd_func_caller!((*self.raw_subsystem).isPlaying, self.raw_player)?;
+        Ok(result == 1)
+    }
+
+    /// Sets the start and end position, in frames, when looping a sample with repeat_count -1.
+    pub fn set_play_range(&self, start: ctypes::c_int, end: ctypes::c_int) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setPlayRange,
+            self.raw_player,
+            start,
+            end
+        )
+    }
+
+    /// Returns the current offset into the sample, in seconds, increasing as it plays.  This is not
+    /// adjusted for rate.
+    pub fn get_offset(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getOffset, self.raw_player)
+    }
+
+    /// Set how far into the sample to start playing, in seconds.  This is not adjusted for rate.
+    pub fn set_offset(&self, offset: f32) -> Result<()> {
+        pd_func_caller!((*self.raw_subsystem).setOffset, self.raw_player, offset)
+    }
+
+    /// Gets the current volume of the left and right audio channels, out of 1.
+    pub fn get_volume(&self) -> Result<(f32, f32)> {
+        let mut left = 0.0;
+        let mut right = 0.0;
+        pd_func_caller!(
+            (*self.raw_subsystem).getVolume,
+            self.raw_player,
+            &mut left,
+            &mut right,
+        )?;
+        Ok((left, right))
+    }
+
+    /// Sets the volume of the left and right audio channels, out of 1.
+    pub fn set_volume(&self, left: f32, right: f32) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setVolume,
+            self.raw_player,
+            left,
+            right
+        )
+    }
+
+    /// Gets the current playback speed.  Returns 1 unless the value was changed by `set_rate` - it
+    /// still returns 1 if the rate is changed with the argument to `play`.
+    pub fn get_rate(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getRate, self.raw_player)
+    }
+
+    /// Sets the playback speed of the player after a sample has started playing.  1.0 is normal,
+    /// 0.5 is down an octave, 2.0 is up one, etc.  A negative rate plays the sample in reverse.
+    pub fn set_rate(&self, playback_speed: f32) -> Result<()> {
+        pd_func_caller!(
+            (*self.raw_subsystem).setRate,
+            self.raw_player,
+            playback_speed
+        )
+    }
+
+    /// Returns the length of the assigned sample, in seconds.
+    pub fn get_length(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getLength, self.raw_player)
+    }
+}
+
+/// A loaded sound effect.
+#[derive(Debug)]
+pub struct AudioSample {
+    raw_subsystem: *const crankstart_sys::playdate_sound_sample,
+    raw_audio_sample: *mut crankstart_sys::AudioSample,
+}
+
+impl Drop for AudioSample {
+    fn drop(&mut self) {
+        // Use _log to leak rather than fail
+        pd_func_caller_log!((*self.raw_subsystem).freeSample, self.raw_audio_sample);
+    }
+}
+
+// Not implemented: getData, newSampleBuffer, loadIntoSample, newSampleFromData -
+// only Sound::load_audio_sample for now.
+impl AudioSample {
+    pub(crate) fn new(
+        raw_subsystem: *const crankstart_sys::playdate_sound_sample,
+        raw_audio_sample: *mut crankstart_sys::AudioSample,
+    ) -> Result<Self, Error> {
+        ensure!(
+            !raw_subsystem.is_null(),
+            "Null pointer given as subsystem to AudioSample::new"
+        );
+        ensure!(
+            !raw_audio_sample.is_null(),
+            "Null pointer given as sample to AudioSample::new"
+        );
+        Ok(Self {
+            raw_subsystem,
+            raw_audio_sample,
+        })
+    }
+
+    /// Returns the length of the sample, in seconds.
+    pub fn get_length(&self) -> Result<f32> {
+        pd_func_caller!((*self.raw_subsystem).getLength, self.raw_audio_sample)
+    }
+}


### PR DESCRIPTION
~Starts to address #32.~ Now with sample (sound effect) and file (music) playback, I think this fixes #32.  APIs for generating sound aren't included, but I think that can be a separate issue.

~I have this working prototype for an audio interface and I was hoping for feedback before I go further.  I'm not experienced with Rust/C interfaces, so there could be mistakes there.  Does this fit crankstart?  Would it expand to the rest of the sound API OK?~  Ready for review!

I mainly patterned this after the graphics module, with some tweaks.  I attempted to follow crankstart and Playdate standards, veering away only where it seemed clear.  The most important change is probably the sound modules/subsystems - the Playdate audio APIs are the largest set of APIs, so I wanted a design that could split out the main subsystems.  `sound` is the top-level, and `sampleplayer` is the specific subsystem I implemented here, for sound effects.

A few specific decisions worth consideration:
* Storing the subsystem pointer (e.g. `*const crankstart_sys::playdate_sound_sampleplayer`) in `Sound` as well as the specific structs `SamplePlayer` and `AudioSample` for convenience.
* Handling errors that I can't really test and aren't documented, e.g. when `play` returns non-1.
* ~The use of `&mut` on the `AudioSample` argument to `set_sample` - I think I originally did this because of the use of `*mut` for arguments all over the place in the bindings, but in the user-facing API, I don't think it matters..?  I should probably make it `&`.~  Made `&` with internal `Rc`; see comments below.

~If this design is basically OK, I'd want to implement `fileplayer` as well before merging, to make sure the modular approach works cleanly, and because `fileplayer` is for music, probably the next most important subsystem after sound effects.  (I don't think I'll need to generate sounds on-device, so most of the remaining APIs aren't as urgent for me.)~  Added.

I tested all of the functions in the simulator, and confirmed playback worked on device.  Docstrings detail any non-obvious behavior I found.

~The only calls I found confusing were `get_offset`/`set_offset`, which were clearly getting through to the Playdate APIs OK (it did offset, and wouldn't go beyond my sample length) but weren't being set exactly to the values I passed through, even with rate 1.0.  I suspect my WAV files may be odd; I'm not very experienced with sound files or APIs.~  I misunderstood the purpose of offset and clarified the docstring.