### PR TITLE
Add text and rotated sprite helpers

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -103,6 +103,39 @@ impl BitmapInner {
         )
     }
 
+    pub fn draw_rotated(
+        &self,
+        location: ScreenPoint,
+        degrees: f32,
+        center: Vector2D<f32>,
+        scale: Vector2D<f32>,
+    ) -> Result<(), Error> {
+        pd_func_caller!(
+            (*Graphics::get_ptr()).drawRotatedBitmap,
+            self.raw_bitmap,
+            location.x,
+            location.y,
+            degrees,
+            center.x,
+            center.y,
+            scale.x,
+            scale.y,
+        )
+    }
+
+    pub fn rotated(&self, degrees: f32, scale: Vector2D<f32>) -> Result<Self, Error> {
+        let raw_bitmap = pd_func_caller!(
+            (*Graphics::get_ptr()).rotatedBitmap,
+            self.raw_bitmap,
+            degrees,
+            scale.x,
+            scale.y,
+            // No documentation on this anywhere, but null works in testing.
+            ptr::null_mut(), // allocedSize
+        )?;
+        Ok(Self { raw_bitmap })
+    }
+
     pub fn tile(
         &self,
         location: ScreenPoint,
@@ -239,6 +272,29 @@ impl Bitmap {
 
     pub fn draw_scaled(&self, location: ScreenPoint, scale: Vector2D<f32>) -> Result<(), Error> {
         self.inner.borrow().draw_scaled(location, scale)
+    }
+
+    /// Draw the `Bitmap` to the given `location`, rotated `degrees` about the `center` point,
+    /// scaled up or down in size by `scale`.  `center` is given by two numbers between 0.0 and
+    /// 1.0, where (0, 0) is the top left and (0.5, 0.5) is the center point.
+    pub fn draw_rotated(
+        &self,
+        location: ScreenPoint,
+        degrees: f32,
+        center: Vector2D<f32>,
+        scale: Vector2D<f32>,
+    ) -> Result<(), Error> {
+        self.inner
+            .borrow()
+            .draw_rotated(location, degrees, center, scale)
+    }
+
+    /// Return a copy of self, rotated by `degrees` and scaled up or down in size by `scale`.
+    pub fn rotated(&self, degrees: f32, scale: Vector2D<f32>) -> Result<Bitmap, Error> {
+        let raw_bitmap = self.inner.borrow().rotated(degrees, scale)?;
+        Ok(Self {
+            inner: Rc::new(RefCell::new(raw_bitmap)),
+        })
     }
 
     pub fn tile(

--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -27,6 +27,7 @@ pub fn rect_make(x: f32, y: f32, width: f32, height: f32) -> PDRect {
     }
 }
 
+#[derive(Clone, Debug)]
 pub enum LCDColor {
     Solid(LCDSolidColor),
     Pattern(LCDPattern),
@@ -699,6 +700,18 @@ impl Graphics {
             font.0,
             c_text.as_ptr() as *const core::ffi::c_void,
             text.len() as usize,
+            PDStringEncoding::kUTF8Encoding,
+            tracking,
+        )
+    }
+
+    pub fn get_system_text_width(&self, text: &str, tracking: i32) -> Result<i32, Error> {
+        let c_text = CString::new(text).map_err(Error::msg)?;
+        pd_func_caller!(
+            (*self.0).getTextWidth,
+            ptr::null_mut(),
+            c_text.as_ptr() as *const core::ffi::c_void,
+            text.len(),
             PDStringEncoding::kUTF8Encoding,
             tracking,
         )


### PR DESCRIPTION
Fixes #35 more fully.

It's a best practice to use sprites for text, but managing sprites and bitmaps and drawing (and figuring out the requisite heights/widths) is a little more complicated than I'd like for simple text.  The first commit adds a `TextSprite` helper that does that for you, with access to the underlying `Sprite` for normal sprite methods.

Similarly, another commit adds `RotatedSprite` which handles storing and rotating a given bitmap and its owning `Sprite`.  It also allows for scaling, since that's bundled in the same Playdate APIs.  Plus binding methods.

Finally, a third commit adds `get_image` so you can inspect the generated bitmaps of the above, in case that's useful.