### PR TITLE
Add sysroot include path for arm-none-eabi-gcc

### DIFF
--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -42,7 +42,7 @@ bindgen $common_params \
 bindgen $common_params \
   -- \
   -I"$PLAYDATE_C_API" \
-  -I"$(which arm-none-eabi-gcc)/../arm-none-eabi/include" \
+  -I"$(arm-none-eabi-gcc -print-sysroot)/include" \
   -target thumbv7em-none-eabihf \
   -fshort-enums \
   -DTARGET_EXTENSION > $crankstart_crate_dir/crankstart-sys/src/bindings_playdate.rs


### PR DESCRIPTION
This switches to using the default include path for arm-none-eabi-gcc, used in generating `bindings_playdate.rs`.

On my system, `arm-none-eabi-gcc -print-sysroot` prints `/usr/arm-none-eabi`, leading to `-I/usr/arm-none-eabi/include`.

The line just above this used a path relative to `$(which arm-none-eabi-gcc)`, which for me is at `/bin/arm-none-eabi-gcc` and therefore didn't work.  **[edit: removed this as unneeded per lilyinstarlight]**