### PR TITLE
Migrate generate_bindings.sh to POSIX sh

### DIFF
--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -1,48 +1,52 @@
-#!/usr/bin/env zsh
+#!/bin/sh
 set -e
 set -x
 
 crankstart_crate_dir="$(cd "$(dirname "$0")/.." >/dev/null 2>&1 && pwd)"
-source "$crankstart_crate_dir/scripts/vars.sh" || exit $?
+. "$crankstart_crate_dir/scripts/vars.sh"
+# shellcheck disable=SC2181  # can't check exit code of . in same line with POSIX sh
+if [ "$?" -ne 0 ]; then
+   exit 2
+fi
 
-common_params=("$crankstart_crate_dir/crankstart-sys/wrapper.h"
-  "--use-core"
-  "--ctypes-prefix"         "ctypes"
-  "--with-derive-default"
-  "--with-derive-eq"
-  "--default-enum-style"    "rust"
-  "--allowlist-type"        "PlaydateAPI"
-  "--allowlist-type"        "PDSystemEvent"
-  "--allowlist-type"        "LCDSolidColor"
-  "--allowlist-type"        "LCDColor"
-  "--allowlist-type"        "LCDPattern"
-  "--allowlist-type"        "PDEventHandler"
-  "--allowlist-var"         "LCD_COLUMNS"
-  "--allowlist-var"         "LCD_ROWS"
-  "--allowlist-var"         "LCD_ROWSIZE"
-  "--allowlist-var"         "SEEK_SET"
-  "--allowlist-var"         "SEEK_CUR"
-  "--allowlist-var"         "SEEK_END"
-  "--bitfield-enum"         "FileOptions"
+# POSIX sh "array" used to store common parameters to all bindgen calls
+set -- "$crankstart_crate_dir/crankstart-sys/wrapper.h" \
+  "--use-core" \
+  "--ctypes-prefix"         "ctypes" \
+  "--with-derive-default" \
+  "--with-derive-eq" \
+  "--default-enum-style"    "rust" \
+  "--allowlist-type"        "PlaydateAPI" \
+  "--allowlist-type"        "PDSystemEvent" \
+  "--allowlist-type"        "LCDSolidColor" \
+  "--allowlist-type"        "LCDColor" \
+  "--allowlist-type"        "LCDPattern" \
+  "--allowlist-type"        "PDEventHandler" \
+  "--allowlist-var"         "LCD_COLUMNS" \
+  "--allowlist-var"         "LCD_ROWS" \
+  "--allowlist-var"         "LCD_ROWSIZE" \
+  "--allowlist-var"         "SEEK_SET" \
+  "--allowlist-var"         "SEEK_CUR" \
+  "--allowlist-var"         "SEEK_END" \
+  "--bitfield-enum"         "FileOptions" \
   "--bitfield-enum"         "PDButtons"
-)
 
-bindgen $common_params \
+bindgen "$@" \
   -- \
   -target x86_64 \
   -I"$PLAYDATE_C_API" \
-  -DTARGET_EXTENSION > $crankstart_crate_dir/crankstart-sys/src/bindings_x86.rs
+  -DTARGET_EXTENSION > "${crankstart_crate_dir}/crankstart-sys/src/bindings_x86.rs"
 
-bindgen $common_params \
+bindgen "$@" \
   -- \
   -target aarch64 \
   -I"$PLAYDATE_C_API" \
-  -DTARGET_EXTENSION > $crankstart_crate_dir/crankstart-sys/src/bindings_aarch64.rs
+  -DTARGET_EXTENSION > "${crankstart_crate_dir}/crankstart-sys/src/bindings_aarch64.rs"
 
-bindgen $common_params \
+bindgen "$@" \
   -- \
   -I"$PLAYDATE_C_API" \
   -I"$(arm-none-eabi-gcc -print-sysroot)/include" \
   -target thumbv7em-none-eabihf \
   -fshort-enums \
-  -DTARGET_EXTENSION > $crankstart_crate_dir/crankstart-sys/src/bindings_playdate.rs
+  -DTARGET_EXTENSION > "${crankstart_crate_dir}/crankstart-sys/src/bindings_playdate.rs"


### PR DESCRIPTION
This removes the need for zsh, with minimal syntactic changes and the same behavior.

~~NOTE: The change on line 45/49 is from #42; I don't think GitHub supports PR dependencies or anything that would let me reflect that this PR depends on that one, it just includes both commits.  I have this marked as a draft so it doesn't get merged first.  (This seemed better than just waiting to submit, or not including the change and having to redo this.)~~  Edit: ready for review now that #42 is merged.