### PR TITLE
Better README, use a rust-toolchain.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,21 @@ This software is not sponsored or supported by Panic.
 
 ## Installation
 
-To use this crate, you'll also need to install the [crank command line tool](https://github.com/rtsuk/crank).
+To use this crate, you'll also need to install the [crank command line tool](https://github.com/pd-rs/crank).
 
-From the crankstart directory where you found this README,
+From the `crankstart` directory where you found this README,
 
-    crank run --release --example hello_world
+```shell
+crank run --release --example hello_world
+```
 
 Should launch the simulator and load in the hello_world sample.
 
 If you have a device attached to your desktop,
 
-    crank run --release --example hello_world --device
+```shell
+crank run --release --example hello_world --device
+```
 
 Should launch the hello_world sample on the device.
 
@@ -26,11 +30,12 @@ For the sprite_game example one needs to copy the images folder from `"PlaydateS
 
 Using this system for your own project requires some setup:
 
-1. Follow the setup for `crank` with Rust nightly's `no_std` support.
-2. Start a new rust library project with `cargo new --lib project_name`
-3. `git clone git@github.com:pd-rs/crankstart.git` at the same depth as your new project.
-4. Go into the new project, and add the following to your `Cargo.toml`:
-
+ 1. Install `crank` from [the repository](https://github.com/pt-rs/crank)
+ 2. Install the rust nightly toolchain with `rustup toolchain install nightly`. This is required for the unstable `alloc` feature. The nightly toolchain will automatically be used for the crankstart project, it does not need to be your default toolchain.
+ 3. Start a new rust library project with `cargo new --lib project_name`
+ 4. `git clone git@github.com:pd-rs/crankstart.git` at the same depth as your new project.
+ 5. Go into the new project, and add the following to your `Cargo.toml`:
+ 
 ```toml
 [package.metadata.cargo-xbuild]
 memcpy = false
@@ -64,7 +69,7 @@ default-features = false
 features = [ "alloc" ]
 ```
 
-5. Add a `Crank.toml` at the same level as your `Cargo.toml`, with this minimum:
+ 6. Add a `Crank.toml` at the same level as your `Cargo.toml`, with this minimum:
 
 ```toml
 [[target]]
@@ -75,8 +80,8 @@ features = [ "alloc" ]
 
 `assets` should be a list of paths to any/all assets you need copied into your project, such as sprites, music, etc.
 
-6. Inside your `lib.rs`, you only need to implement the `crankstart::Game` trait to your game's core state struct, then call `crankstart::crankstart_game!` on that struct. See the `examples` folder for examples.
-7. To run the project, from its root, you should now be able to `crank run` successfully!
+ 7. Inside your `lib.rs`, you only need to implement the `crankstart::Game` trait to your game's core state struct, then call `crankstart::crankstart_game!` on that struct. See the `examples` folder for examples.
+ 8. To run the project, its root, you should now be able to `crank run` successfully!
 
 If you want an example of an independent project following these conventions, go check out [Nine Lives](https://github.com/bravely/nine_lives).
 

--- a/README.md
+++ b/README.md
@@ -80,8 +80,15 @@ features = [ "alloc" ]
 
 `assets` should be a list of paths to any/all assets you need copied into your project, such as sprites, music, etc.
 
- 7. Inside your `lib.rs`, you only need to implement the `crankstart::Game` trait to your game's core state struct, then call `crankstart::crankstart_game!` on that struct. See the `examples` folder for examples.
- 8. To run the project, its root, you should now be able to `crank run` successfully!
+7. Add a 'rust-toolchain.toml' the same level as your 'Cargo.toml', with this minimum:
+
+```toml
+[toolchain]
+channel = "nightly"
+```
+
+ 8. Inside your `lib.rs`, you only need to implement the `crankstart::Game` trait to your game's core state struct, then call `crankstart::crankstart_game!` on that struct. See the `examples` folder for examples.
+ 9. To run the project, its root, you should now be able to `crank run` successfully!
 
 If you want an example of an independent project following these conventions, go check out [Nine Lives](https://github.com/bravely/nine_lives).
 

--- a/README.md
+++ b/README.md
@@ -92,8 +92,8 @@ Here's a guide.
 
 1. Install [the dependencies for bindgen](https://rust-lang.github.io/rust-bindgen/requirements.html).
 2. Install [bindgen-cli](https://rust-lang.github.io/rust-bindgen/command-line-usage.html).
-3. Install the gcc-arm-none-eabi toolchain, either [manually](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) or through a system package, which may also be named something like "cross-arm-none-eabi-gcc".
-4. On Linux, install the 32-bit glibc development package, which will be called something like `glibc-devel-32bit`.
+3. Install the `gcc-arm-none-eabi` toolchain, either [manually](https://developer.arm.com/Tools%20and%20Software/GNU%20Toolchain) or through a system package, such as `gcc-arm-none-eabi` on Ubuntu Linux or something like `cross-arm-none-eabi-gcc`.
+4. On Linux, install the 32-bit glibc development package, which will be called something like `gcc-multilib` in Ubuntu or `glibc-devel-32bit` in Fedora.
 5. Install the new [Playdate SDK](https://play.date/dev/), and if it's not at the default MacOS path, set `PLAYDATE_SDK_PATH` to where you unzipped it.  (This should be the directory that contains `C_API`, `CoreLibs`, etc.)
 6. Run `./scripts/generate_bindings.sh`
 7. Inspect the changes to `crankstart-sys/src/bindings_*` - they should reflect the updates to the Playdate C API.  If nothing changed, double-check that the C API actually changed and not just the Lua API.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -43,9 +43,12 @@ bindgen "$@" \
   -I"$PLAYDATE_C_API" \
   -DTARGET_EXTENSION > "${crankstart_crate_dir}/crankstart-sys/src/bindings_aarch64.rs"
 
+# /usr/include is here because under some versions of Linux (such as Mint 21.1)
+# the arm-non-eabi-gcc -print-sysroot command outputs nothing
 bindgen "$@" \
   -- \
   -I"$PLAYDATE_C_API" \
+  -I"/usr/include" \
   -I"$(arm-none-eabi-gcc -print-sysroot)/include" \
   -target thumbv7em-none-eabihf \
   -fshort-enums \

--- a/scripts/generate_bindings.sh
+++ b/scripts/generate_bindings.sh
@@ -43,12 +43,13 @@ bindgen "$@" \
   -I"$PLAYDATE_C_API" \
   -DTARGET_EXTENSION > "${crankstart_crate_dir}/crankstart-sys/src/bindings_aarch64.rs"
 
-# /usr/include is here because under some versions of Linux (such as Mint 21.1)
-# the arm-non-eabi-gcc -print-sysroot command outputs nothing
+# The `which arm-none-eabi-gcc` is here because under some versions of Ubuntu 23.04
+# and Linux Mint 21.1 arm-non-eabi-gcc are built without support for printing
+# the sysroot.
 bindgen "$@" \
   -- \
   -I"$PLAYDATE_C_API" \
-  -I"/usr/include" \
+  -I"$(which arm-none-eabi-gcc)/../include" \
   -I"$(arm-none-eabi-gcc -print-sysroot)/include" \
   -target thumbv7em-none-eabihf \
   -fshort-enums \


### PR DESCRIPTION
Better README and a rust-toolchain.toml means avoid having to manually switch to nightly