### PR TITLE
Make `euclid` optional for the `crankstart-sys` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 anyhow = { version = "1.0.31", default-features = false }
-crankstart-sys = { version = "0.1.1", path = "crankstart-sys", features = ["euclid"] }
+crankstart-sys = { version = "0.1.1", path = "crankstart-sys" }
 euclid = { version = "0.20.13", default-features = false, features = [ "libm" ] }
 hashbrown = "0.7.2"
 heapless = "0.6.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 anyhow = { version = "1.0.31", default-features = false }
-crankstart-sys = { version = "0.1.1", path = "crankstart-sys" }
+crankstart-sys = { version = "0.1.1", path = "crankstart-sys", features = ["euclid"] }
 euclid = { version = "0.20.13", default-features = false, features = [ "libm" ] }
 hashbrown = "0.7.2"
 heapless = "0.6.1"

--- a/crankstart-sys/Cargo.toml
+++ b/crankstart-sys/Cargo.toml
@@ -9,5 +9,8 @@ repository = "https://github.com/pd-rs/crankstart"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[features]
+default = ["euclid"]
+
 [dependencies]
 euclid = { version = "0.20.13", default-features = false, features = [ "libm" ], optional = true }

--- a/crankstart-sys/Cargo.toml
+++ b/crankstart-sys/Cargo.toml
@@ -10,4 +10,4 @@ repository = "https://github.com/pd-rs/crankstart"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-euclid = { version = "0.20.13", default-features = false, features = [ "libm" ] }
+euclid = { version = "0.20.13", default-features = false, features = [ "libm" ], optional = true }

--- a/crankstart-sys/src/lib.rs
+++ b/crankstart-sys/src/lib.rs
@@ -75,6 +75,7 @@ include!("bindings_aarch64.rs");
 #[cfg(target_os = "none")]
 include!("bindings_playdate.rs");
 
+#[cfg(feature = "euclid")]
 impl From<euclid::default::Rect<i32>> for LCDRect {
     fn from(r: euclid::default::Rect<i32>) -> Self {
         LCDRect {
@@ -86,12 +87,14 @@ impl From<euclid::default::Rect<i32>> for LCDRect {
     }
 }
 
+#[cfg(feature = "euclid")]
 impl From<LCDRect> for euclid::default::Rect<i32> {
     fn from(r: LCDRect) -> Self {
         euclid::rect(r.left, r.top, r.right - r.left, r.bottom - r.top)
     }
 }
 
+#[cfg(feature = "euclid")]
 impl From<euclid::default::Rect<f32>> for PDRect {
     fn from(r: euclid::default::Rect<f32>) -> Self {
         PDRect {
@@ -103,6 +106,7 @@ impl From<euclid::default::Rect<f32>> for PDRect {
     }
 }
 
+#[cfg(feature = "euclid")]
 impl From<PDRect> for euclid::default::Rect<f32> {
     fn from(r: PDRect) -> Self {
         euclid::rect(r.x, r.y, r.width, r.height)


### PR DESCRIPTION
Hi, 

Thank you for creating this, I'm having fun using `crankstart-sys` crate  :-)

As I don't need the `euclid` crate (because I'm using [`glam`](https://docs.rs/glam/latest/glam/) instead),
It would be great if I could avoid pulling dependencies I don't need.

I suggest making it optional, so crates that want it  (i.e. the `crankstart` crate) can have it, and other consumers can opt-out.

What do you think?