### PR TITLE
Fix drawing order of sprites and other graphics

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -712,7 +712,6 @@ impl Graphics {
         start_angle: f32,
         end_angle: f32,
         color: LCDColor,
-        clip: LCDRect,
     ) -> Result<(), Error> {
         pd_func_caller!(
             (*self.0).fillEllipse,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,14 +141,14 @@ impl<T: 'static + Game> GameRunner<T> {
         }
 
         if let Some(game) = self.game.as_mut() {
-            match game.update(&mut self.playdate) {
-                Err(err) => log_to_console!("Error in update: {}", err),
-                _ => (),
-            }
             match SpriteManager::get_mut().update_and_draw_sprites() {
                 Err(err) => {
                     log_to_console!("Error from sprite_manager.update_and_draw_sprites: {}", err)
                 }
+                _ => (),
+            }
+            match game.update(&mut self.playdate) {
+                Err(err) => log_to_console!("Error in update: {}", err),
                 _ => (),
             }
             if game.draw_fps() {


### PR DESCRIPTION
I'm not sure why but `playdate->sprite->updateAndDrawSprites(void)` in the C API seems to clear the screen before drawing anything. So a game that allocates any sprites through the `SpriteManager` will be unable to draw things in the `Game::update()` method anymore because that method is called before sprite updates within `crankshaft` (even if the sprites are never added to the manager).

To fix this, I swapped the order of `update_and_draw_sprites()` and `Game::update()` in `crankshaft`'s update method. I tested the linked `nine_lives` repo before and after this change.

Before:
<img width="400" alt="1" src="https://github.com/pd-rs/crankstart/assets/6700637/d69f11cd-24b2-4c07-aaef-4ca925672ccf">

After:
<img width="400" alt="2" src="https://github.com/pd-rs/crankstart/assets/6700637/99ec4527-f18a-4d2f-b819-5fe13719b126">

I also had to remove the call to `Graphics.clear()` in the update method for it to work correctly.

As for how to draw behind sprites given this change, from what I understand the Lua API provides [a method](https://sdk.play.date/2.0.3/Inside%20Playdate.html#f-graphics.sprite.setBackgroundDrawingCallback) that allocates a "background sprite" and allows you to specify how it should be rendered. But there isn't an equivalent function in the C API, and there's nothing mentioning this screen clearing behavior in either the Lua or C API documentation. I'm assuming that drawing things behind sprites with the core graphics API is unsupported for some reason, and this method would have to be reimplemented in `crankshaft`.