### PR TITLE
Update euclid and hashbrown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,8 @@ crate-type = ["staticlib", "cdylib"]
 [dependencies]
 anyhow = { version = "1.0.31", default-features = false }
 crankstart-sys = { version = "0.1.2", path = "crankstart-sys" }
-euclid = { version = "0.20.13", default-features = false, features = [ "libm" ] }
-hashbrown = "0.7.2"
+euclid = { version = "0.22.9", default-features = false, features = [ "libm" ] }
+hashbrown = "0.14.0"
 heapless = "0.6.1"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ crate-type = ["staticlib", "cdylib"]
 crankstart = { path = "../crankstart" }
 crankstart-sys = { path = "../crankstart/crankstart-sys" }
 anyhow = { version = "1.0.31", default-features = false }
-euclid = { version = "0.20.13", default-features = false, features = [ "libm" ] }
-hashbrown = "0.7.2"
-heapless = "0.5.5"
+euclid = { version = "0.22.9", default-features = false, features = [ "libm" ] }
+hashbrown = "0.14.0"
+heapless = "0.6.1"
 
 [dependencies.cstr_core]
 version = "=0.1.2"

--- a/crankstart-sys/Cargo.toml
+++ b/crankstart-sys/Cargo.toml
@@ -13,4 +13,4 @@ repository = "https://github.com/pd-rs/crankstart"
 default = ["euclid"]
 
 [dependencies]
-euclid = { version = "0.20.13", default-features = false, features = [ "libm" ], optional = true }
+euclid = { version = "0.22.9", default-features = false, features = [ "libm" ], optional = true }


### PR DESCRIPTION
There are other dependencies that are out of date, but these are trivial to update.

I wanted to use `euclid` directly in my game to keep duplicate dependencies down. But I also want a modern version of it!