### PR TITLE
Add get_sprite_count, remove_sprite, get_userdata and set_userdata

### DIFF
--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -140,7 +140,7 @@ extern "C" fn get_sprite_collision_response(
 }
 
 impl SpriteInner {
-    pub fn get_userdata<T>(&mut self) -> Result<Rc<Box<T>>, Error>
+    pub fn get_userdata<T>(&self) -> Result<Rc<Box<T>>, Error>
     where
         T: Userdata,
     {
@@ -370,10 +370,7 @@ impl Sprite {
     where
         T: Userdata,
     {
-        self.inner
-            .try_borrow_mut()
-            .map_err(Error::msg)?
-            .get_userdata()
+        self.inner.try_borrow().map_err(Error::msg)?.get_userdata()
     }
 
     pub fn set_userdata<T>(&mut self, userdata: Rc<Box<T>>) -> Result<(), Error>

--- a/src/sprite.rs
+++ b/src/sprite.rs
@@ -140,6 +140,19 @@ extern "C" fn get_sprite_collision_response(
 }
 
 impl SpriteInner {
+    pub fn get_userdata<T>(&mut self) -> Result<Box<T>, Error> {
+        let ptr = pd_func_caller!((*self.playdate_sprite).getUserdata, self.raw_sprite)? as *mut T;
+        Ok(unsafe { Box::from_raw(ptr) })
+    }
+
+    pub fn set_userdata<T>(&mut self, userdata: T) -> Result<(), Error> {
+        pd_func_caller!(
+            (*self.playdate_sprite).setUserdata,
+            self.raw_sprite,
+            Box::into_raw(Box::new(userdata)) as *mut core::ffi::c_void
+        )
+    }
+
     pub fn set_use_custom_draw(&mut self) -> Result<(), Error> {
         self.set_draw_function(unsafe { SPRITE_DRAW.expect("SPRITE_DRAW") })
     }
@@ -318,6 +331,20 @@ pub struct Sprite {
 }
 
 impl Sprite {
+    pub fn get_userdata<T>(&mut self) -> Result<Box<T>, Error> {
+        self.inner
+            .try_borrow_mut()
+            .map_err(Error::msg)?
+            .get_userdata()
+    }
+
+    pub fn set_userdata<T>(&mut self, userdata: T) -> Result<(), Error> {
+        self.inner
+            .try_borrow_mut()
+            .map_err(Error::msg)?
+            .set_userdata(userdata)
+    }
+
     pub fn set_use_custom_draw(&mut self) -> Result<(), Error> {
         self.inner
             .try_borrow_mut()


### PR DESCRIPTION
I wound up needing access to more of the sprite API for my game. I found this worked for me, but I'm not a wiz with smart pointers so I may have done some questionable things.

I might want to mark get_userdata as unsafe, just because it is dependent on T matching what was passed to set_userdata which can get dicey