### PR TITLE
Optionally draw and update sprites

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,10 @@ pub trait Game {
     fn draw_fps(&self) -> bool {
         false
     }
+
+    fn draw_and_update_sprites(&self) -> bool {
+        true
+    }
 }
 
 pub type GamePtr<T> = Box<T>;
@@ -145,11 +149,16 @@ impl<T: 'static + Game> GameRunner<T> {
                 Err(err) => log_to_console!("Error in update: {}", err),
                 _ => (),
             }
-            match SpriteManager::get_mut().update_and_draw_sprites() {
-                Err(err) => {
-                    log_to_console!("Error from sprite_manager.update_and_draw_sprites: {}", err)
+            if game.draw_and_update_sprites() {
+                match SpriteManager::get_mut().update_and_draw_sprites() {
+                    Err(err) => {
+                        log_to_console!(
+                            "Error from sprite_manager.update_and_draw_sprites: {}",
+                            err
+                        )
+                    }
+                    _ => (),
                 }
-                _ => (),
             }
             if game.draw_fps() {
                 match System::get().draw_fps(0, 0) {


### PR DESCRIPTION
As an alternative to https://github.com/pd-rs/crankstart/pull/52, I'd like to propose making the drawing and updating of sprites into an optional call, similar to draw_fps. This way, if needed, you could opt out of the call here, and call it manually in your update method wherever it may be necessary if you want to draw shapes or text after sprites.