### PR TITLE
Rename center to origin in ellipse function params

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -682,7 +682,7 @@ impl Graphics {
 
     pub fn draw_ellipse(
         &self,
-        center: ScreenPoint,
+        origin: ScreenPoint,
         size: ScreenSize,
         line_width: i32,
         start_angle: f32,
@@ -691,8 +691,8 @@ impl Graphics {
     ) -> Result<(), Error> {
         pd_func_caller!(
             (*self.0).drawEllipse,
-            center.x,
-            center.y,
+            origin.x,
+            origin.y,
             size.width,
             size.height,
             line_width,
@@ -706,7 +706,7 @@ impl Graphics {
         &self,
         target: OptionalBitmap,
         stencil: OptionalBitmap,
-        center: ScreenPoint,
+        origin: ScreenPoint,
         size: ScreenSize,
         line_width: i32,
         start_angle: f32,
@@ -716,8 +716,8 @@ impl Graphics {
     ) -> Result<(), Error> {
         pd_func_caller!(
             (*self.0).fillEllipse,
-            center.x,
-            center.y,
+            origin.x,
+            origin.y,
             size.width,
             size.height,
             start_angle,


### PR DESCRIPTION
Fixes https://github.com/pd-rs/crankstart/issues/65