### PR TITLE
Add missing functions from the original API

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -58,6 +58,15 @@ impl System {
         pd_func_caller!((*self.0).getCrankChange,)
     }
 
+    pub fn set_crank_sound_disabled(&self, disable: bool) -> Result<bool, Error> {
+        let last = pd_func_caller!((*self.0).setCrankSoundsDisabled, disable as i32)?;
+        Ok(last != 0)
+    }
+
+    pub fn set_auto_lock_disabled(&self, disable: bool) -> Result<(), Error> {
+        pd_func_caller!((*self.0).setAutoLockDisabled, disable as i32)
+    }
+
     pub fn log_to_console(text: &str) {
         unsafe {
             if SYSTEM.0 != ptr::null_mut() {


### PR DESCRIPTION
# New Features
* `system.set_auto_lock_disabled(true)` will disable Playdate's autolock feature
* `system.set_crank_sound_disabled(true)` will disable the sound the console makes when the crank is docked/undocked