### PR TITLE
Add most missing system features

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -144,7 +144,23 @@ impl System {
         Ok(pd_func_caller!((*self.0).getElapsedTime)? as f32)
     }
 
+    pub fn get_flipped(&self) -> Result<bool, Error> {
+        Ok(pd_func_caller!((*self.0).getFlipped)? != 0)
+    }
+
+    pub fn get_reduced_flashing(&self) -> Result<bool, Error> {
+        Ok(pd_func_caller!((*self.0).getReduceFlashing)? != 0)
+    }
+
     pub fn draw_fps(&self, x: i32, y: i32) -> Result<(), Error> {
         pd_func_caller!((*self.0).drawFPS, x, y)
+    }
+
+    pub fn get_battery_percentage(&self) -> Result<f32, Error> {
+        pd_func_caller!((*self.0).getBatteryPercentage)
+    }
+
+    pub fn get_battery_voltage(&self) -> Result<f32, Error> {
+        pd_func_caller!((*self.0).getBatteryVoltage)
     }
 }

--- a/src/system.rs
+++ b/src/system.rs
@@ -5,6 +5,7 @@ use {
 
 use crankstart_sys::ctypes::c_int;
 pub use crankstart_sys::PDButtons;
+use crankstart_sys::PDDateTime;
 
 static mut SYSTEM: System = System(ptr::null_mut());
 
@@ -115,6 +116,24 @@ impl System {
 
     pub fn get_current_time_milliseconds(&self) -> Result<usize, Error> {
         Ok(pd_func_caller!((*self.0).getCurrentTimeMilliseconds)? as usize)
+    }
+
+    pub fn get_timezone_offset(&self) -> Result<i32, Error> {
+        pd_func_caller!((*self.0).getTimezoneOffset)
+    }
+
+    pub fn convert_epoch_to_datetime(&self, epoch: u32) -> Result<PDDateTime, Error> {
+        let mut datetime = PDDateTime::default();
+        pd_func_caller!((*self.0).convertEpochToDateTime, epoch, &mut datetime)?;
+        Ok(datetime)
+    }
+
+    pub fn convert_datetime_to_epoch(&self, datetime: &mut PDDateTime) -> Result<usize, Error> {
+        Ok(pd_func_caller!((*self.0).convertDateTimeToEpoch, datetime)? as usize)
+    }
+
+    pub fn should_display_24_hour_time(&self) -> Result<bool, Error> {
+        Ok(pd_func_caller!((*self.0).shouldDisplay24HourTime)? != 0)
     }
 
     pub fn reset_elapsed_time(&self) -> Result<(), Error> {

--- a/src/system.rs
+++ b/src/system.rs
@@ -153,7 +153,7 @@ impl System {
     }
 
     pub fn get_elapsed_time(&self) -> Result<f32, Error> {
-        Ok(pd_func_caller!((*self.0).getElapsedTime)? as f32)
+        pd_func_caller!((*self.0).getElapsedTime)
     }
 
     pub fn get_flipped(&self) -> Result<bool, Error> {

--- a/src/system.rs
+++ b/src/system.rs
@@ -5,7 +5,7 @@ use {
 
 use crankstart_sys::ctypes::c_int;
 pub use crankstart_sys::PDButtons;
-use crankstart_sys::PDDateTime;
+use crankstart_sys::{PDDateTime, PDLanguage, PDPeripherals};
 
 static mut SYSTEM: System = System(ptr::null_mut());
 
@@ -45,6 +45,18 @@ impl System {
             &mut released
         )?;
         Ok((current, pushed, released))
+    }
+
+    pub fn set_peripherals_enabled(&self, peripherals: PDPeripherals) -> Result<(), Error> {
+        pd_func_caller!((*self.0).setPeripheralsEnabled, peripherals)
+    }
+
+    pub fn get_accelerometer(&self) -> Result<(f32, f32, f32), Error> {
+        let mut outx = 0.0;
+        let mut outy = 0.0;
+        let mut outz = 0.0;
+        pd_func_caller!((*self.0).getAccelerometer, &mut outx, &mut outy, &mut outz)?;
+        Ok((outx, outy, outz))
     }
 
     pub fn is_crank_docked(&self) -> Result<bool, Error> {
@@ -162,5 +174,9 @@ impl System {
 
     pub fn get_battery_voltage(&self) -> Result<f32, Error> {
         pd_func_caller!((*self.0).getBatteryVoltage)
+    }
+
+    pub fn get_language(&self) -> Result<PDLanguage, Error> {
+        pd_func_caller!((*self.0).getLanguage)
     }
 }


### PR DESCRIPTION
# Additions
* Added all of the remaining datetime functions
* Added most of the remaining misc functions
* Added all of the remaining peripheral features

# Fixes
* `get_elapsed_time` was casting the returned `f32` into an `f32`

# Questions
Currently all of the datetime functions return epoch as `usize`, but `convert_epoch_to_datetime` takes the epoch argument as `u32` for fears of downcasting. Should this be changed into `usize` or should I leave it as is?