### PR TITLE
Replace heapless with the much smaller arrayvec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,10 +44,10 @@ crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 anyhow = { version = "1.0.31", default-features = false }
+arrayvec = { version = "0.7.4", default-features = false }
 crankstart-sys = { version = "0.1.2", path = "crankstart-sys" }
 euclid = { version = "0.22.9", default-features = false, features = [ "libm" ] }
 hashbrown = "0.14.0"
-heapless = "0.6.1"
 
 [dev-dependencies]
 randomize = "3.0.1"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ crankstart-sys = { path = "../crankstart/crankstart-sys" }
 anyhow = { version = "1.0.31", default-features = false }
 euclid = { version = "0.22.9", default-features = false, features = [ "libm" ] }
 hashbrown = "0.14.0"
-heapless = "0.6.1"
 
 [dependencies.cstr_core]
 version = "=0.1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,12 +292,10 @@ fn abort_with_addr(addr: usize) -> ! {
 
 #[panic_handler]
 fn panic(#[allow(unused)] panic_info: &PanicInfo) -> ! {
-    use {
-        core::fmt::Write,
-        heapless::{consts::*, String},
-    };
+    use arrayvec::ArrayString;
+    use core::fmt::Write;
     if let Some(location) = panic_info.location() {
-        let mut output: String<U1024> = String::new();
+        let mut output = ArrayString::<1024>::new();
         let payload = if let Some(payload) = panic_info.payload().downcast_ref::<&str>() {
             payload
         } else {


### PR DESCRIPTION
`heapless` has surprisingly a lot of dependencies, and the only thing it is used for is a stack-allocated string in the panic handler. None of these dependencies are needed.

```
├── crankstart v0.1.2
│   ├── anyhow v1.0.75
│   ├── crankstart-sys v0.1.2
│   ├── cstr_core v0.1.2
│   │   ├── cty v0.1.5
│   │   └── memchr v2.6.3
│   ├── euclid v0.22.9 (*)
│   ├── hashbrown v0.14.0 (*)
│   └── heapless v0.6.1
│       ├── as-slice v0.1.5
│       │   ├── generic-array v0.12.4
│       │   │   └── typenum v1.16.0
│       │   ├── generic-array v0.13.3
│       │   │   └── typenum v1.16.0
│       │   ├── generic-array v0.14.7
│       │   │   └── typenum v1.16.0
│       │   └── stable_deref_trait v1.2.0
│       ├── generic-array v0.14.7 (*)
│       ├── hash32 v0.1.1
│       │   └── byteorder v1.4.3
│       └── stable_deref_trait v1.2.0
```

After replacing it with `arrayvec`:

```
├── crankstart v0.1.2
│   ├── anyhow v1.0.75
│   ├── arrayvec v0.7.4
│   ├── crankstart-sys v0.1.2
│   ├── cstr_core v0.1.2
│   │   ├── cty v0.1.5
│   │   └── memchr v2.6.3
│   ├── euclid v0.22.9 (*)
│   └── hashbrown v0.14.0 (*)
```

Much better!