### PR TITLE
Fix macro expansion errors

### DIFF
--- a/src/graphics.rs
+++ b/src/graphics.rs
@@ -756,8 +756,8 @@ impl Graphics {
         let c_path = CString::new(path).map_err(Error::msg)?;
         let mut out_err: *const crankstart_sys::ctypes::c_char = ptr::null_mut();
         let font = pd_func_caller!((*self.0).loadFont, c_path.as_ptr(), &mut out_err)?;
-        if font == ptr::null_mut() {
-            if out_err != ptr::null_mut() {
+        if font.is_null() {
+            if !out_err.is_null() {
                 let err_msg = unsafe { CStr::from_ptr(out_err).to_string_lossy().into_owned() };
                 Err(anyhow!(err_msg))
             } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ impl<T: 'static + Game> GameRunner<T> {
 #[macro_export]
 macro_rules! crankstart_game {
     ($game_struct:tt) => {
-        crankstart_game!($game_struct, PDSystemEvent::kEventInit)
+        crankstart_game!($game_struct, PDSystemEvent::kEventInit);
     };
     ($game_struct:tt, $pd_system_event:expr) => {
         pub mod game_setup {

--- a/src/lua.rs
+++ b/src/lua.rs
@@ -27,7 +27,7 @@ impl Lua {
         let c_name = CString::new(name).map_err(Error::msg)?;
         let mut out_err: *const crankstart_sys::ctypes::c_char = ptr::null_mut();
         pd_func_caller!((*self.0).addFunction, f, c_name.as_ptr(), &mut out_err)?;
-        if out_err != ptr::null_mut() {
+        if !out_err.is_null() {
             let err_msg = unsafe { CStr::from_ptr(out_err).to_string_lossy().into_owned() };
             Err(anyhow!(err_msg))
         } else {


### PR DESCRIPTION
`crankstart_game` lacked `;` and caused syntax errors, add it back.
Also fix a couple of nullptr clippy lints.

![image](https://github.com/pd-rs/crankstart/assets/2690773/90c60209-89c4-4120-87a1-86aafbecd5dd)
