### PR TITLE
Menu item API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,11 @@ path = "examples/hello_world.rs"
 crate-type = ["staticlib", "cdylib"]
 
 [[example]]
+name = "menu_items"
+path = "examples/menu_items.rs"
+crate-type = ["staticlib", "cdylib"]
+
+[[example]]
 name = "life"
 path = "examples/life.rs"
 crate-type = ["staticlib", "cdylib"]

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,6 +9,7 @@ use {
         crankstart_game,
         geometry::{ScreenPoint, ScreenVector},
         graphics::{Graphics, LCDColor, LCDSolidColor},
+        log_to_console,
         system::System,
         Game, Playdate,
     },
@@ -24,6 +25,24 @@ struct State {
 impl State {
     pub fn new(_playdate: &Playdate) -> Result<Box<Self>, Error> {
         crankstart::display::Display::get().set_refresh_rate(20.0)?;
+        System::get().add_menu_item(
+            "Say Hello",
+            Box::new(|| {
+                log_to_console!("Hello");
+            }),
+        )?;
+        System::get().add_menu_item(
+            "Say Goodbye",
+            Box::new(|| {
+                log_to_console!("Goodbye");
+            }),
+        )?;
+        System::get().add_menu_item(
+            "Sausage",
+            Box::new(|| {
+                log_to_console!("Sausage");
+            }),
+        )?;
         Ok(Box::new(Self {
             location: point2(INITIAL_X, INITIAL_Y),
             velocity: vec2(1, 2),

--- a/examples/hello_world.rs
+++ b/examples/hello_world.rs
@@ -9,7 +9,6 @@ use {
         crankstart_game,
         geometry::{ScreenPoint, ScreenVector},
         graphics::{Graphics, LCDColor, LCDSolidColor},
-        log_to_console,
         system::System,
         Game, Playdate,
     },
@@ -25,24 +24,6 @@ struct State {
 impl State {
     pub fn new(_playdate: &Playdate) -> Result<Box<Self>, Error> {
         crankstart::display::Display::get().set_refresh_rate(20.0)?;
-        System::get().add_menu_item(
-            "Say Hello",
-            Box::new(|| {
-                log_to_console!("Hello");
-            }),
-        )?;
-        System::get().add_menu_item(
-            "Say Goodbye",
-            Box::new(|| {
-                log_to_console!("Goodbye");
-            }),
-        )?;
-        System::get().add_menu_item(
-            "Sausage",
-            Box::new(|| {
-                log_to_console!("Sausage");
-            }),
-        )?;
         Ok(Box::new(Self {
             location: point2(INITIAL_X, INITIAL_Y),
             velocity: vec2(1, 2),

--- a/examples/menu_items.rs
+++ b/examples/menu_items.rs
@@ -1,0 +1,106 @@
+#![no_std]
+
+extern crate alloc;
+
+use alloc::{format, vec};
+use alloc::rc::Rc;
+use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use hashbrown::HashMap;
+use {
+    alloc::boxed::Box,
+    anyhow::Error,
+    crankstart::{
+        crankstart_game,
+        geometry::{ScreenPoint, ScreenVector},
+        graphics::{Graphics, LCDColor, LCDSolidColor},
+        log_to_console,
+        system::{System, MenuItem},
+        Game, Playdate,
+    },
+    crankstart_sys::{LCD_COLUMNS, LCD_ROWS},
+    euclid::{point2, vec2},
+};
+
+struct State {
+    menu_items: Rc<RefCell<HashMap<&'static str, MenuItem>>>,
+    text_location: ScreenPoint,
+}
+
+impl State {
+    pub fn new(_playdate: &Playdate) -> Result<Box<Self>, Error> {
+        crankstart::display::Display::get().set_refresh_rate(20.0)?;
+        let menu_items = Rc::new(RefCell::new(HashMap::new()));
+        let system = System::get();
+        let normal_item = {
+            system.add_menu_item(
+                "Select Me",
+                Box::new(|| {
+                    log_to_console!("Normal option picked");
+                }
+                ),
+            )?
+        };
+        let checkmark_item = {
+            let ref_menu_items = menu_items.clone();
+            system.add_checkmark_menu_item(
+                "Toggle Me",
+                false,
+                Box::new(move || {
+                    let value_of_item = {
+                        let menu_items = ref_menu_items.borrow();
+                        let this_menu_item = menu_items.get("checkmark").unwrap();
+                        System::get().get_menu_item_value(this_menu_item).unwrap() != 0
+                    };
+                    log_to_console!("Checked option picked: Value is now: {}", value_of_item);
+                }),
+            )?
+        };
+        let options_item = {
+            let ref_menu_items = menu_items.clone();
+            let options : Vec<String>= vec!["Small".into(), "Medium".into(), "Large".into()];
+            let options_copy = options.clone();
+            system.add_options_menu_item(
+                "Size",
+                options,
+                Box::new(move || {
+                    let value_of_item = {
+                        let menu_items = ref_menu_items.borrow();
+                        let this_menu_item = menu_items.get("checkmark").unwrap();
+                        let idx = System::get().get_menu_item_value(this_menu_item).unwrap();
+                        options_copy.get(idx as usize)
+                    };
+                    log_to_console!("Checked option picked: Value is now {:?}", value_of_item);
+                }),
+            )?
+        };
+        {
+            let mut menu_items = menu_items.borrow_mut();
+            menu_items.insert("normal", normal_item);
+            menu_items.insert("checkmark", checkmark_item);
+            menu_items.insert("options", options_item);
+        }
+        Ok(Box::new(Self {
+            menu_items,
+            text_location: point2(100, 100),
+
+        }
+        ))
+    }
+}
+
+impl Game for State {
+    fn update(&mut self, _playdate: &mut Playdate) -> Result<(), Error> {
+        let graphics = Graphics::get();
+        graphics.clear(LCDColor::Solid(LCDSolidColor::kColorWhite))?;
+        graphics.draw_text("Menu Items", self.text_location);
+
+        System::get().draw_fps(0, 0)?;
+
+        Ok(())
+    }
+}
+
+
+crankstart_game!(State);

--- a/examples/menu_items.rs
+++ b/examples/menu_items.rs
@@ -2,28 +2,28 @@
 
 extern crate alloc;
 
-use alloc::vec;
 use alloc::rc::Rc;
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 
 use hashbrown::HashMap;
 
+use crankstart::system::MenuItemKind;
 use {
     alloc::boxed::Box,
     anyhow::Error,
     crankstart::{
         crankstart_game,
-        Game,
         geometry::ScreenPoint,
         graphics::{Graphics, LCDColor, LCDSolidColor},
         log_to_console,
-        Playdate, system::{MenuItem, System},
+        system::{MenuItem, System},
+        Game, Playdate,
     },
     euclid::point2,
 };
-use crankstart::system::MenuItemKind;
 
 struct State {
     _menu_items: Rc<RefCell<HashMap<&'static str, MenuItem>>>,
@@ -40,8 +40,7 @@ impl State {
                 "Select Me",
                 Box::new(|| {
                     log_to_console!("Normal option picked");
-                }
-                ),
+                }),
             )?
         };
         let checkmark_item = {
@@ -71,10 +70,8 @@ impl State {
                         let this_menu_item = menu_items.get("options").unwrap();
                         let idx = System::get().get_menu_item_value(this_menu_item).unwrap();
                         match &this_menu_item.kind {
-                            MenuItemKind::Options(opts) => {
-                                opts.get(idx ).map(|s| s.clone())
-                            }
-                            _ => None
+                            MenuItemKind::Options(opts) => opts.get(idx).map(|s| s.clone()),
+                            _ => None,
                         }
                     };
                     log_to_console!("Checked option picked: Value is now {:?}", value_of_item);
@@ -98,13 +95,14 @@ impl Game for State {
     fn update(&mut self, _playdate: &mut Playdate) -> Result<(), Error> {
         let graphics = Graphics::get();
         graphics.clear(LCDColor::Solid(LCDSolidColor::kColorWhite))?;
-        graphics.draw_text("Menu Items", self.text_location).unwrap();
+        graphics
+            .draw_text("Menu Items", self.text_location)
+            .unwrap();
 
         System::get().draw_fps(0, 0)?;
 
         Ok(())
     }
 }
-
 
 crankstart_game!(State);

--- a/src/system.rs
+++ b/src/system.rs
@@ -207,9 +207,6 @@ impl System {
     fn remove_menu_item_internal(&self, item_inner: &MenuItemInner) -> Result<(), Error> {
         pd_func_caller!((*self.0).removeMenuItem, item_inner.item)
     }
-    pub fn remove_all_menu_items(&self) -> Result<(), Error> {
-        pd_func_caller!((*self.0).removeAllMenuItems)
-    }
 
     pub fn set_peripherals_enabled(&self, peripherals: PDPeripherals) -> Result<(), Error> {
         pd_func_caller!((*self.0).setPeripheralsEnabled, peripherals)

--- a/src/system.rs
+++ b/src/system.rs
@@ -8,7 +8,7 @@ use anyhow::anyhow;
 
 use crankstart_sys::ctypes::{c_char, c_int};
 pub use crankstart_sys::PDButtons;
-use crankstart_sys::PDMenuItem;
+use crankstart_sys::{PDDateTime, PDLanguage, PDMenuItem, PDPeripherals};
 use {
     crate::pd_func_caller, anyhow::Error, core::ptr, crankstart_sys::ctypes::c_void,
     cstr_core::CString,
@@ -53,7 +53,7 @@ impl System {
         )?;
         Ok((current, pushed, released))
     }
-  
+
     extern "C" fn menu_item_callback(user_data: *mut core::ffi::c_void) {
         unsafe {
             let callback = user_data as *mut Box<dyn Fn()>;

--- a/src/system.rs
+++ b/src/system.rs
@@ -16,10 +16,6 @@ use {
 
 static mut SYSTEM: System = System(ptr::null_mut());
 
-static mut MENU_ITEM_CALLBACKS: Vec<Box<dyn Fn()>> = Vec::new();
-const MENU_ITEM_CALLBACKS_MAX: usize = 10;
-const MENU_ITEM_INDICES: [c_int; MENU_ITEM_CALLBACKS_MAX] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
-
 #[derive(Clone, Debug)]
 pub struct System(*const crankstart_sys::playdate_sys);
 


### PR DESCRIPTION
Exposes an api in `System` for adding (etc) menu items.

Slightly painful since it involves passing callbacks into C but it's handled by double-boxing dynamic Fn() trait objects.

There's some degree of code around handling the possible kinds of MenuItem values (as MenuItemKind).
Potentially one could go a step further so users do not have the directly deal with the index value and can get
its typed (bool or string) accordingly.

Adds a new example that adds one of each menu item 