### PR TITLE
Resolve platform dependent cstr point types for menu API

### DIFF
--- a/src/system.rs
+++ b/src/system.rs
@@ -127,7 +127,7 @@ impl System {
             .iter()
             .map(|s| CString::new(s.clone()).map_err(|e| anyhow!("CString::new: {}", e)))
             .collect::<Result<Vec<CString>, Error>>()?;
-        let c_options_ptrs: Vec<*const u8> = c_options.iter().map(|c| c.as_ptr()).collect();
+        let c_options_ptrs: Vec<*const c_char> = c_options.iter().map(|c| c.as_ptr()).collect();
         let c_options_ptrs_ptr = c_options_ptrs.as_ptr();
         let option_titles = c_options_ptrs_ptr as *mut *const c_char;
         let wrapped_callback = Box::new(callback);


### PR DESCRIPTION
Resolves the types being used to represent cstring pointers in the menu API
being platform dependent.

Speficially I originally wrote it using i8 but it turns out other platforms use u8.
[See the docs ](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr) for more

> The type of the returned pointer is [*const c_char](https://doc.rust-lang.org/std/ffi/type.c_char.html), and whether it’s an alias for *const i8 or *const u8 is platform-specific.

So we never force this into one of the two, and just use the `ffi::c_char` type as returned by `CString::as_ptr`

This refers to
#79 
and
#82 