### PR TITLE
allow game struct to be in a submodule

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,10 +204,10 @@ impl<T: 'static + Game> GameRunner<T> {
 
 #[macro_export]
 macro_rules! crankstart_game {
-    ($game_struct:tt) => {
+    ($game_struct:ty) => {
         crankstart_game!($game_struct, PDSystemEvent::kEventInit);
     };
-    ($game_struct:tt, $pd_system_event:expr) => {
+    ($game_struct:ty, $pd_system_event:expr) => {
         pub mod game_setup {
             extern crate alloc;
             use super::*;
@@ -262,7 +262,7 @@ macro_rules! crankstart_game {
                         .unwrap_or_else(|err| {
                             log_to_console!("Got error while setting update callback: {err:#}");
                         });
-                    let game = match $game_struct::new(&mut playdate) {
+                    let game = match <$game_struct>::new(&mut playdate) {
                         Ok(game) => Some(game),
                         Err(err) => {
                             log_to_console!("Got error while creating game: {err:#}");


### PR DESCRIPTION
This allows the following in lib.rs:

```
crankstart_game!(playdate::MyGameStruct);
```

Without these changes the above would fail with:

```
error: no rules expected the token `::`
   --> src/lib.rs:15:26
    |
15  | crankstart_game!(playdate::MyGameStruct);
    |                          ^^ no rules expected this token in macro call
    |
```