### PR TITLE
Add explicit return type to pd_func_caller macro to resolve type annotations error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,7 +73,7 @@ macro_rules! pd_func_caller {
             use alloc::format;
             let raw_fn = $raw_fn_opt
                 .ok_or_else(|| anyhow::anyhow!("{} did not contain a function pointer", stringify!($raw_fn_opt)))?;
-            Ok(raw_fn($($arg)*))
+            Ok::<_, Error>(raw_fn($($arg)*))
         }
     };
     ($raw_fn_opt:expr) => {
@@ -81,7 +81,7 @@ macro_rules! pd_func_caller {
             use alloc::format;
             let raw_fn = $raw_fn_opt
                 .ok_or_else(|| anyhow::anyhow!("{} did not contain a function pointer", stringify!($raw_fn_opt)))?;
-            Ok(raw_fn())
+            Ok::<_, Error>(raw_fn())
         }
     };
 }


### PR DESCRIPTION
Explicitly specifying the return type fixes the type annotation errors reported in #93 

```
error[E0282]: type annotations needed
  --> src/lib.rs:84:13
   |
84 |             Ok(raw_fn())
   |             ^^^^^^^^^^^^ cannot infer type
   |
  ::: src/display.rs:25:13
   |
25 |             pd_func_caller!((*self.0).getWidth)?,
   |             ----------------------------------- in this macro invocation
   |
   = note: this error originates in the macro `pd_func_caller` (in Nightly builds, run with -Z macro-backtrace for more info)
```

Tested with:

- M1 Macbook Pro (2021) running macOS Sequoia 15.3.2
- rustc 1.88.0-nightly (d5b4c2e4f 2025-04-02)
- Playdate SDK 2.6.2